### PR TITLE
Update train data(departure_day以外)

### DIFF
--- a/tabimae-api/app/serializers/air_serializer.rb
+++ b/tabimae-api/app/serializers/air_serializer.rb
@@ -1,8 +1,8 @@
 class AirSerializer < ActiveModel::Serializer
-  attributes :id, :departure_day, :departure_time, :arrival_time, :departure_place, :arrival_place, :flight_number, :airline, :user_id, :travel_id, :username
+  attributes :id, :departure_day, :departure_time, :arrival_time, :departure_place, :arrival_place, :flight_number, :airline, :user_id, :travel_id
   belongs_to :travel
 
-  def username
-    object.user.name
-  end
+  # def username
+  #   object.user.name
+  # end
 end

--- a/tabimae-api/app/serializers/train_serializer.rb
+++ b/tabimae-api/app/serializers/train_serializer.rb
@@ -1,8 +1,8 @@
 class TrainSerializer < ActiveModel::Serializer
-  attributes :id, :departure_day, :departure_time, :arrival_time, :departure_place, :arrival_place, :user_id, :travel_id, :username
+  attributes :id, :departure_day, :departure_time, :arrival_time, :departure_place, :arrival_place, :user_id, :travel_id
   belongs_to :travel
 
-  def username
-    object.user.name
-  end
+  # def username
+  #   object.user.name
+  # end
 end

--- a/tabimae-web/package-lock.json
+++ b/tabimae-web/package-lock.json
@@ -10400,6 +10400,11 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
     },
+    "vue2-timepicker": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/vue2-timepicker/-/vue2-timepicker-1.1.5.tgz",
+      "integrity": "sha512-jMbw3BhVguuukwfzO7jvS2Ais7zDX/I9OjFO59IZU7cNv9EfxFAcU7MxDK85FwJLsSTm+ZTMIXAZPnGLLrFLwA=="
+    },
     "vuetify": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.4.0.tgz",

--- a/tabimae-web/package.json
+++ b/tabimae-web/package.json
@@ -15,6 +15,7 @@
     "css-loader": "^5.0.1",
     "firebase": "^8.1.2",
     "nuxt": "^2.14.6",
+    "vue2-timepicker": "^1.1.5",
     "vuetify": "^2.4.0"
   },
   "devDependencies": {

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -17,24 +17,16 @@
           <v-text-field v-model="departure_place" :counter="10" label="出発地" required></v-text-field>
           <v-text-field v-model="arrival_place" :counter="10" label="到着地" required></v-text-field>
         </v-col>
-        <v-row justify="center">
-        <v-col cols="8">
-          <v-text-field v-model="departure_day" single-line>
-            <template v-slot:append-outer>
-              <date-picker v-model="departure_day"/>
-            </template>
-          </v-text-field>
-        </v-col>
-        <v-col cols="8">
-          <p>日付： {{ departure_day }}</p>
-        </v-col>
-      </v-row>
+            <vue-timepicker  format="A:h:mm:"></vue-timepicker>
+
       </template>
 
       <template v-if="transport === 'air'">
         <h1>飛行機で行く</h1>
-      <v-text-field v-model="departure_place" :counter="10" label="出発地" required></v-text-field>
-      <v-text-field v-model="arrival_place" :counter="10" label="到着地" required></v-text-field>
+        <v-col cols="12" md="4">
+          <v-text-field v-model="departure_place" :counter="10" label="出発地" required></v-text-field>
+          <v-text-field v-model="arrival_place" :counter="10" label="到着地" required></v-text-field>
+        </v-col>
       </template>
 
       <v-col cols="12" md="4">
@@ -49,8 +41,12 @@
 
 <script>
 import axios from "@/plugins/axios";
-
+import VueTimepicker from 'vue2-timepicker'
+import 'vue2-timepicker/dist/VueTimepicker.css'
 export default {
+   components: {
+            'vue-timepicker': VueTimepicker,
+        },
   data() {
     return {
       travel: "",
@@ -59,7 +55,6 @@ export default {
       departure_place: "",
       arrival_place: "",
       success: false,
-      departure_day: null,
     };
   },
   methods: {

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -18,7 +18,7 @@
           <v-text-field v-model="arrival_place" :counter="10" label="到着地" required></v-text-field>
         </v-col>
           <p>出発時間</p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
-          <!-- <p></p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker> -->
+          <p>到着時間</p><vue-timepicker v-model="arrival_time" format="A:h:mm:"></vue-timepicker>
       </template>
 
       <template v-if="transport === 'air'">
@@ -54,7 +54,8 @@ export default {
       name: "",
       departure_place: "",
       arrival_place: "",
-      departure_time: "",
+      departure_time: null,
+      arrival_time: null,
       success: false,
     };
   },
@@ -95,6 +96,7 @@ export default {
           departure_place: this.departure_place,
           arrival_place: this.arrival_place,
           departure_time: this.departure_time,
+          arrival_time: this.arrival_time,
           user_id: this.$store.state.auth.currentUser.id
         };
         console.log(train_params);
@@ -103,7 +105,7 @@ export default {
         this.departure_place = "";
         this.arrival_place = "";
         this.departure_time = "";
-
+        this.arrival_time = "";
 
       }
       // this.$router.push 詳細画面へ遷移。

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -93,7 +93,7 @@ export default {
           travel_id: data.id,
           departure_place: this.departure_place,
           arrival_place: this.arrival_place,
-          departure_time: this.departure_day,
+          departure_time: this.departure_time,
           user_id: this.$store.state.auth.currentUser.id
         };
         console.log(train_params);
@@ -110,7 +110,8 @@ export default {
   },
   computed: {
     user() {
-      return this.$store.state.auth.currentUser;
+      return
+      this.$store.state.auth.currentUser;
     }
   }
 };

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -17,9 +17,22 @@
           <v-text-field v-model="departure_place" :counter="10" label="出発地" required></v-text-field>
           <v-text-field v-model="arrival_place" :counter="10" label="到着地" required></v-text-field>
         </v-col>
+        <v-row justify="center">
+        <v-col cols="8">
+          <v-text-field v-model="departure_day" single-line>
+            <template v-slot:append-outer>
+              <date-picker v-model="departure_day"/>
+            </template>
+          </v-text-field>
+        </v-col>
+        <v-col cols="8">
+          <p>日付： {{ departure_day }}</p>
+        </v-col>
+      </v-row>
       </template>
 
       <template v-if="transport === 'air'">
+        <h1>飛行機で行く</h1>
       <v-text-field v-model="departure_place" :counter="10" label="出発地" required></v-text-field>
       <v-text-field v-model="arrival_place" :counter="10" label="到着地" required></v-text-field>
       </template>
@@ -46,26 +59,27 @@ export default {
       departure_place: "",
       arrival_place: "",
       success: false,
-      departure_date: ""
+      departure_day: null,
     };
   },
   methods: {
     async createTravel() {
-      const travel = {
+      const travel_params = {
         transport: this.transport,
         name: this.name,
         user_id: this.$store.state.auth.currentUser.id
       };
-      console.log(travel);
-      const { data } = await axios.post("/v1/travels", { travel });
+      console.log(travel_params);
+      const { data } = await axios.post("/v1/travels", { travel: travel_params });
       console.log(data.id);
       this.transport = "";
       this.name = "";
       this.success = true;
 
       if (this.transport === "air") {
+        console.log(data);
         const air_params = {
-          travel_id: data.data.id,
+          travel_id: data.id,
           departure_place: this.departure_place,
           arrival_place: this.arrival_place,
           user_id: this.$store.state.auth.currentUser.id
@@ -75,19 +89,19 @@ export default {
           //カラムたくさん追加します
         };
         console.log(air_params);
-        const res_air = await axios.post("/v1/airs", { air_params });
+        const res_air = await axios.post("/v1/airs", { air: air_params });
         console.log(res_air);
         this.departure_place = "";
         this.arrival_place = "";
       } else {
         const train_params = {
-          travel_id: data.data.id,
+          travel_id: data.id,
           departure_place: this.departure_place,
           arrival_place: this.arrival_place,
           user_id: this.$store.state.auth.currentUser.id
         };
         console.log(train_params);
-        const res_train = await axios.post("/v1/trains", { train_params });
+        const res_train = await axios.post("/v1/trains", { train: train_params });
         console.log(res_train);
         this.departure_place = "";
         this.arrival_place = "";

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -17,8 +17,7 @@
           <v-text-field v-model="departure_place" :counter="10" label="出発地" required></v-text-field>
           <v-text-field v-model="arrival_place" :counter="10" label="到着地" required></v-text-field>
         </v-col>
-            <vue-timepicker  format="A:h:mm:"></vue-timepicker>
-
+          <vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
       </template>
 
       <template v-if="transport === 'air'">
@@ -44,9 +43,9 @@ import axios from "@/plugins/axios";
 import VueTimepicker from 'vue2-timepicker'
 import 'vue2-timepicker/dist/VueTimepicker.css'
 export default {
-   components: {
-            'vue-timepicker': VueTimepicker,
-        },
+  components: {
+      'vue-timepicker': VueTimepicker,
+  },
   data() {
     return {
       travel: "",
@@ -54,6 +53,7 @@ export default {
       name: "",
       departure_place: "",
       arrival_place: "",
+      departure_time: "",
       success: false,
     };
   },
@@ -93,6 +93,7 @@ export default {
           travel_id: data.id,
           departure_place: this.departure_place,
           arrival_place: this.arrival_place,
+          departure_time: this.departure_day,
           user_id: this.$store.state.auth.currentUser.id
         };
         console.log(train_params);
@@ -100,6 +101,8 @@ export default {
         console.log(res_train);
         this.departure_place = "";
         this.arrival_place = "";
+        this.departure_time = "";
+
 
       }
       // this.$router.push 詳細画面へ遷移。

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -17,7 +17,8 @@
           <v-text-field v-model="departure_place" :counter="10" label="出発地" required></v-text-field>
           <v-text-field v-model="arrival_place" :counter="10" label="到着地" required></v-text-field>
         </v-col>
-          <vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
+          <p>出発時間</p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
+          <!-- <p></p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker> -->
       </template>
 
       <template v-if="transport === 'air'">

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -19,6 +19,7 @@
         </v-col>
           <p>出発時間</p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
           <p>到着時間</p><vue-timepicker v-model="arrival_time" format="A:h:mm:"></vue-timepicker>
+            
       </template>
 
       <template v-if="transport === 'air'">
@@ -56,8 +57,11 @@ export default {
       arrival_place: "",
       departure_time: null,
       arrival_time: null,
+
       success: false,
     };
+
+
   },
   methods: {
     async createTravel() {
@@ -116,6 +120,7 @@ export default {
       return
       this.$store.state.auth.currentUser;
     }
+
   }
 };
 </script>


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
旅行情報新規登録
#21 
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
列車で行く場合の出発地/到着地/出発時間/到着時間が登録できるようになりました。
# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
列車と飛行機でそれぞれtemolateで区切りました。
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
現状、出発日は未達の状態。
飛行機の場合を登録後取り掛かります。